### PR TITLE
FIX exventModule .on to .once

### DIFF
--- a/eventModulejs/index.js
+++ b/eventModulejs/index.js
@@ -22,6 +22,18 @@ const event = new EventEmitter();
 
 //   event.emit('sayMyName');
 
+
+// 3. registering for the event to be fired only one time using once
+// event.once('sayMyName', () => {
+//   console.log("your name is indranil");
+// });
+// event.emit('sayMyName'); // only once it will be printed
+// event.emit('sayMyName'); // only once it will be printed
+// event.emit('sayMyName'); // only once it will be printed
+// event.emit('sayMyName'); // only once it will be printed
+// done by ankit for hacotberfest
+
+
 //   3. Registering for the event with callback parameters
 
 event.on('checkPage',(sc,msg,port) => {


### PR DESCRIPTION
// 3. registering for the event to be fired only one time using once
// event.once('sayMyName', () => {
//   console.log("your name is indranil");
// });
// event.emit('sayMyName'); // only once it will be printed
// event.emit('sayMyName'); // only once it will be printed
// event.emit('sayMyName'); // only once it will be printed
// event.emit('sayMyName'); // only once it will be printed
// done by ankit for hacotberfest


added this comment because if we want to emit event only once then we must have to use .once not .on 